### PR TITLE
FIX: Raise `Discourse::NotFound` when route is blocked

### DIFF
--- a/lib/route_blocker_controller.rb
+++ b/lib/route_blocker_controller.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class RouteBlockerController < ApplicationController
-  def blocked
-    render json: { error: "Not Found" }, status: :not_found
-  end
-end

--- a/lib/route_blocker_middleware.rb
+++ b/lib/route_blocker_middleware.rb
@@ -22,7 +22,7 @@ class RouteBlockerMiddleware
 
   def call(env)
     if SiteSetting.route_blocker_enabled && is_blocked?(env)
-      RouteBlockerController.action("blocked").call(env)
+      raise Discourse::NotFound.new
     else
       @app.call(env)
     end

--- a/spec/system/route_blocker_spec.rb
+++ b/spec/system/route_blocker_spec.rb
@@ -1,35 +1,48 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 RSpec.describe "Route Blocker", type: :system do
   before do
     SiteSetting.route_blocker_enabled = true
     SiteSetting.route_blocker_blocked_routes = "about|site/statistics|faq"
   end
 
+  def expect_json_error
+    expect(page).to have_content(
+      "{\"errors\":[\"The requested URL or resource could not be found.\"],\"error_type\":\"not_found\"}",
+    )
+  end
+
+  def expect_page_not_found
+    expect(page).to have_css(".page-not-found")
+  end
+
   it "blocks access to the about page" do
     visit "/about"
-    expect(page).to have_current_path("/404")
+
+    expect_page_not_found
   end
 
   it "blocks access to the about.json endpoint" do
     visit "/about.json"
-    expect(page).to have_content('{"error":"Not Found"}')
+
+    expect_json_error
   end
 
   it "blocks access to the site statistics page" do
     visit "/site/statistics"
-    expect(page).to have_css(".page-not-found")
+
+    expect_page_not_found
   end
 
   it "blocks access to the site statistics.json endpoint" do
     visit "/site/statistics.json"
-    expect(page).to have_content('{"error":"Not Found"}')
+
+    expect_json_error
   end
 
   it "blocks access to the faq page" do
     visit "/faq"
-    expect(page).to have_css(".still-loading")
+
+    expect_page_not_found
   end
 end


### PR DESCRIPTION
This allows us to rely on the `rescue_from` exception handler in
`ApplicationController` instead of having to create a "fake" controller
